### PR TITLE
READMEロゴマークの表示改善とリンクの解決

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-<img height="200px" src="doc/assets/logo.png">
+<img width="100%" src="https://raw.githubusercontent.com/RikitoNoto/camel/master/doc/assets/logo.png">
 
 # Camel
-[日本語](doc/README.jp.md)<br/>
+[日本語](https://github.com/RikitoNoto/camel/blob/master/doc/README.jp.md)<br/>
 
 Flutter package that allows communicating in a local network.
 

--- a/doc/README.jp.md
+++ b/doc/README.jp.md
@@ -1,7 +1,7 @@
-<img height="200px" src="assets/logo.png">
+<img width="100%" src="https://raw.githubusercontent.com/RikitoNoto/camel/master/doc/assets/logo.png">
 
 # Camel
-[English](../README.md)<br/>
+[English](https://github.com/RikitoNoto/camel/blob/master/README.md)<br/>
 
 ローカルネットワークで通信を行うためのFlutterパッケージ。
 


### PR DESCRIPTION
# READMEロゴマークの表示改善とリンクの解決

## 内容
### 対応
 - [x] リンクをすべてgithubへのリンクに変更
 - [x] ロゴマークのサイズを横幅100%にして、横幅が異なる場合に高さは可変になるように修正

### 経緯
- ロゴマークが[dart.pub](https://pub.dev/packages/camel)で表示されていなかった。
- 日本語のリンクが[dart.pub](https://pub.dev/packages/camel)から表示できなかった。
- ロゴマークがモバイル版で表示するとつぶれていた。
  <img src="https://github.com/RikitoNoto/camel/assets/56541594/4590bb09-0ad5-46ad-a2f8-f5f7bb0d9b38" width="200px">

## テスト
 - [x] モバイル版で表示を確認 
   <img src="https://github.com/RikitoNoto/camel/assets/56541594/d0c4acfc-c084-4b35-82e5-b3232749ad9c" width="200px">

 - [x] リンクが機能することを本ブランチで確認
